### PR TITLE
Added case handling for requests that would cause the API to throw an error

### DIFF
--- a/node/middlewares/status.ts
+++ b/node/middlewares/status.ts
@@ -5,20 +5,46 @@ export async function status(ctx: Context, next: () => Promise<any>) {
   } = ctx
   console.log('Received code:', code)
 
-  const statusResponse = await statusClient.getStatus(code)
+  const statusResponse = await statusClient.getStatus(code).then(result => result,
+    error => {
+      if (error.response === undefined) {
+        return { code:400, description:"Bad Request" }
+      }
+      else {
+        if(error.response.data != undefined){
+          return error.response.data
+        }
+        return { code: error.response.status, description:error.response.statusResponseText}
+      }
+    })
   console.log('Status response:', statusResponse)
+
+  console.log('Code:', code)
 
   const {
     headers,
     data,
     status: responseStatus,
-  } = await statusClient.getStatusWithHeaders(code)
+  } = await statusClient.getStatusWithHeaders(code).then(result => {
+    if(typeof result.data == "string") {
+      return statusClient.getStatusWithHeaders(400).catch(error => error.response)
+    }
+    return result
+  },
+    error => {
+      if(error.response == undefined || typeof error.response.data == "string" || code < 100 || code > 599) {
+        return statusClient.getStatusWithHeaders(400).catch(error => error.response)
+      }
+      else {
+        return error.response
+      }
+    })
   console.log('Status headers', headers)
   console.log('Status data:', data)
 
   ctx.status = responseStatus
   ctx.body = data
-  ctx.set('Cache-Control', headers['cache-control'])
+  ctx.set('Cache-Control', 'no-cache')
 
   await next()
 }

--- a/node/middlewares/status.ts
+++ b/node/middlewares/status.ts
@@ -19,8 +19,6 @@ export async function status(ctx: Context, next: () => Promise<any>) {
     })
   console.log('Status response:', statusResponse)
 
-  console.log('Code:', code)
-
   const {
     headers,
     data,
@@ -44,7 +42,7 @@ export async function status(ctx: Context, next: () => Promise<any>) {
 
   ctx.status = responseStatus
   ctx.body = data
-  ctx.set('Cache-Control', 'no-cache')
+  ctx.set('Cache-Control', headers['cache-control'])
 
   await next()
 }


### PR DESCRIPTION
The API used to deal with the HTTP requests would throw and error when given almost all codes. Now the behavior is standardized, returning the requested code's information when available or a Bad Request otherwise.