### PR TITLE
Fix: lint.sh -- return to root folder before yarn lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `lint.sh`: return to app root folder before running `yarn lint`
+
 ## [0.2.25] - 2024-03-18
 
 ### Added

--- a/lint.sh
+++ b/lint.sh
@@ -4,4 +4,5 @@ cd node/
 [ -d node_modules ] && rm -rf node_modules
 yarn cache clean
 yarn  --frozen-lockfile
+cd ..
 yarn lint


### PR DESCRIPTION
#### What is the purpose of this pull request?

To fix an issue in the recently introduced `lint.sh` file.

#### What problem is this solving?

When committing to Git, the `lint.sh` script is invoked and, in the existing version, runs `yarn lint` inside the `node` folder, which triggers `tsc --noEmit --pretty` to run. This consistently results in a linting error as the `tsc` command lints dependency packages in addition to the main code of the app. 

By introducing a `cd ..` before the `yarn lint` command, this PR solves the issue because `yarn lint` in the root triggers `eslint --ext js,jsx,ts,tsx .` to run instead of `tsc`, and this command only lints the main codebase of the app. 

#### How to test it?

Create a custom app based on this template and commit it to a GitHub repo.

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
